### PR TITLE
DelayAtLeast extension

### DIFF
--- a/kt-extensions/src/main/kotlin/com/mindera/skeletoid/kt/extensions/rxjava/Observable.kt
+++ b/kt-extensions/src/main/kotlin/com/mindera/skeletoid/kt/extensions/rxjava/Observable.kt
@@ -4,8 +4,11 @@ package com.mindera.skeletoid.kt.extensions.rxjava
 
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.functions.BiFunction
 import io.reactivex.schedulers.Schedulers
+import java.lang.Exception
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 fun <T : Any> Observable<T>.subscribeOnIO(): Observable<T> = subscribeOn(Schedulers.io())
 
@@ -28,6 +31,22 @@ fun <T : Any> Observable<T>.createUniqueConcurrentRequestCache(requestMap: Concu
 
     requestMap[key] = obs
     return obs
+}
+
+/**
+ * Holds an item and an exception. Used in [delayAtLeast]
+ */
+internal data class DataHolder<T>(val something: T? = null, val throwable: Throwable? = null)
+
+/**
+ * Extension that always waits for at least timeToWait in the provided timeUnit before emitting. This will happen even if an exception is thrown. Used to prevent loadings to just blink when a connection is too fast.
+ *
+ * @param timeToWait - the time to wait
+ * @param timeUnit - the unit of timeToWait
+ */
+fun <T> Observable<T>.delayAtLeast(timeToWait: Long = 1000, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): Observable<T> {
+    return Observable.zip<DataHolder<T>, Long, DataHolder<T>>(this.map { DataHolder(something = it) }.onErrorReturn { DataHolder(throwable = it) },
+            Observable.timer(timeToWait, timeUnit), BiFunction { t, _ -> t }).map { it.something ?: it.throwable?.let { throwable -> throw throwable } ?: throw Exception() }
 }
 
 fun <T> Observable<T>.allowMultipleSubscribers(): Observable<T> =


### PR DESCRIPTION
Added extension function that delays a stream for at least a specified amount of time. It works even when there is an error.