### PR TITLE
Changes the schedulers on the QA build to trampoline

### DIFF
--- a/rxjava/build.gradle
+++ b/rxjava/build.gradle
@@ -9,14 +9,15 @@ android {
     testBuildType "qa"
 
     defaultConfig {
-
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
-
     }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        release.java.srcDirs += 'src/main/kotlin'
+        debug.java.srcDirs += 'src/debug/kotlin'
+        qa.java.srcDirs += 'src/qa/kotlin'
     }
 
     buildTypes {
@@ -31,6 +32,7 @@ android {
         }
 
         release {
+            matchingFallbacks = ['debug']
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/rxjava/build.gradle
+++ b/rxjava/build.gradle
@@ -15,7 +15,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
-        release.java.srcDirs += 'src/main/kotlin'
+        release.java.srcDirs += 'src/debug/kotlin'
         debug.java.srcDirs += 'src/debug/kotlin'
         qa.java.srcDirs += 'src/qa/kotlin'
     }

--- a/rxjava/src/debug/kotlin/com/mindera/skeletoid/rxjava/schedulers/Schedulers.kt
+++ b/rxjava/src/debug/kotlin/com/mindera/skeletoid/rxjava/schedulers/Schedulers.kt
@@ -20,5 +20,4 @@ object Schedulers {
     fun computation(): Scheduler = io.reactivex.schedulers.Schedulers.from(computationThreadPool)
 
     fun io(): Scheduler = io.reactivex.schedulers.Schedulers.from(ioThreadPool)
-
 }

--- a/rxjava/src/main/AndroidManifest.xml
+++ b/rxjava/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mindera.skeletoid" />
+    package="com.mindera.skeletoid.rxjava" />

--- a/rxjava/src/qa/kotlin/com/mindera/skeletoid/rxjava/schedulers/Schedulers.kt
+++ b/rxjava/src/qa/kotlin/com/mindera/skeletoid/rxjava/schedulers/Schedulers.kt
@@ -1,0 +1,12 @@
+package com.mindera.skeletoid.rxjava.schedulers
+
+import io.reactivex.Scheduler
+
+/**
+ * Change the schedulers to trampoline to make the unit tests run in a sequentially predictable order,
+ * before the assertions code run.
+ */
+object Schedulers {
+    fun computation(): Scheduler = io.reactivex.schedulers.Schedulers.trampoline()
+    fun io(): Scheduler = io.reactivex.schedulers.Schedulers.trampoline()
+}


### PR DESCRIPTION
- Changes the schedulers on the QA build to make the unit tests run in a sequentially predictable order, ie.: before the assertions code run.

https://medium.com/@PaulinaSadowska/writing-unit-tests-on-asynchronous-events-with-rxjava-and-rxkotlin-1616a27f69aa