### PR TITLE
Changed RxJava module package name

### DIFF
--- a/rxjava/src/main/AndroidManifest.xml
+++ b/rxjava/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mindera.skeletoid" />
+    package="com.mindera.skeletoid.rxjava" />


### PR DESCRIPTION
If both `base` and `RxJava` modules are included in the same module, an error would be shown with the message `Program type already present: ...BuildConfig`