### PR TITLE
CookieUtils - Fixed cookie parsing

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/webview/cookies/CookiesUtils.kt
+++ b/base/src/main/java/com/mindera/skeletoid/webview/cookies/CookiesUtils.kt
@@ -19,7 +19,7 @@ object CookiesUtils {
         val cookieManager = CookieManager.getInstance()
         val cookies = cookieManager.getCookie(url)
 
-        val temp = cookies.split(";".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val temp = cookies.split(";".toRegex()).map { it.trim() }.dropLastWhile { it.isEmpty() }.toTypedArray()
 
         for (ar1 in temp) {
             val temp1 = ar1.split("=".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()


### PR DESCRIPTION
We were not accounting for spaces on the parsing, now we do.