### PR TITLE
Ability to attach user properties to the logger appenders.

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/logs/ILoggerManager.java
+++ b/base/src/main/java/com/mindera/skeletoid/logs/ILoggerManager.java
@@ -61,4 +61,12 @@ public interface ILoggerManager {
      * Disable all log appenders
      */
     void removeAllAppenders();
+
+    /**
+     * Sets a custom property of the user
+     *
+     * @param key Property key
+     * @param value Property value
+     */
+    void setUserProperty(String key, String value);
 }

--- a/base/src/main/java/com/mindera/skeletoid/logs/LOG.java
+++ b/base/src/main/java/com/mindera/skeletoid/logs/LOG.java
@@ -14,7 +14,6 @@ import java.util.Set;
  */
 public class LOG {
 
-
     public enum PRIORITY {
         VERBOSE, DEBUG, INFO, ERROR, WARN, FATAL
     }
@@ -348,5 +347,16 @@ public class LOG {
         return mInstance != null;
     }
 
-
+    /**
+     * Sets a custom property of the user
+     *
+     * @param key Property key
+     * @param value Property value
+     */
+    public static void setUserProperty(String key, String value) {
+        if (mInstance == null) {
+            return;
+        }
+        mInstance.setUserProperty(key, value);
+    }
 }

--- a/base/src/main/java/com/mindera/skeletoid/logs/LoggerManager.java
+++ b/base/src/main/java/com/mindera/skeletoid/logs/LoggerManager.java
@@ -123,6 +123,13 @@ class LoggerManager implements ILoggerManager {
         }
     }
 
+    @Override
+    public void setUserProperty(String key, String value) {
+        for (ILogAppender logAppender : mLogAppenders.values()) {
+            logAppender.setUserProperty(key, value);
+        }
+    }
+
     public void setMethodNameVisible(boolean visibility) {
         mAddMethodName = visibility;
     }

--- a/base/src/main/java/com/mindera/skeletoid/logs/appenders/ILogAppender.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/appenders/ILogAppender.kt
@@ -39,7 +39,17 @@ interface ILogAppender {
      *
      * @param type Type of log
      * @param t    Throwable (can be null)
-     * @param log  Log
+     * @param logs  Log
      */
-    fun log(type: LOG.PRIORITY, t: Throwable?, vararg log: String)
+    fun log(type: LOG.PRIORITY, t: Throwable?, vararg logs: String)
+
+    /**
+     * Sets a custom property of the user.
+     * Default implementation does nothing since there are logging services
+     * that don't need to set user properties.
+     *
+     * @param key  Property name
+     * @param value Property value
+     */
+    fun setUserProperty(key: String, value: String?) {}
 }

--- a/base/src/main/java/com/mindera/skeletoid/logs/appenders/LogcatAppender.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/appenders/LogcatAppender.kt
@@ -42,14 +42,14 @@ class LogcatAppender(private val TAG: String) : ILogAppender {
         //Nothing needed here
     }
 
-    override fun log(type: LOG.PRIORITY, t: Throwable?, vararg log: String) {
+    override fun log(type: LOG.PRIORITY, t: Throwable?, vararg logs: String) {
         if (type.ordinal < minLogLevel.ordinal) {
             return
         }
-        val logString = getLogString(*log)
-        val logs = formatLog(logString)
+        val logString = getLogString(*logs)
+        val formattedLogs = formatLog(logString)
 
-        for (logText in logs) {
+        for (logText in formattedLogs) {
 
             when (type) {
                 LOG.PRIORITY.VERBOSE -> Log.v(TAG, logText, t)


### PR DESCRIPTION
Remote logging services usually allow us to associate extra data to a device or account in order to identify it easily. The default implementation does nothing since there are platforms that don't need/allow to set any user property.