### PR TITLE
Feature/AppRatingDialog

### DIFF
--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
@@ -1,6 +1,7 @@
 package com.mindera.skeletoid.apprating
 
 import android.content.Context
+import androidx.fragment.app.FragmentManager
 import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogCallback
 import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogResponse
 import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogResponseCallback
@@ -52,17 +53,17 @@ object AppRatingInitializer {
      * Only one of the callbacks can be null.
      *
      * @param context Context
-     * @param dialogResultCallback Callback to handle responses to the default dialog. Null if it uses a custom dialog.
+     * @param fragmentManager Fragment Manager to show default dialog
      */
     fun promptDialog(
         context: Context,
-        dialogResultCallback: AppRatingDialogResponseCallback? = null
+        fragmentManager: FragmentManager? = null
     ) {
         if (controller.shouldPromptDialog(context)) {
             controller.updateStore(context)
             when {
-                ::callback.isInitialized && dialogResultCallback == null -> callback.showRatingDialog()
-                !::callback.isInitialized && dialogResultCallback != null -> LOG.d(LOG_TAG, "Calling default dialog TO BE IMPLEMENTED")
+                ::callback.isInitialized && fragmentManager == null -> callback.showRatingDialog()
+                !::callback.isInitialized && fragmentManager != null -> controller.showDefaultDialog(fragmentManager)
                 else -> throw IllegalArgumentException("Should have one non-nullable callback")
             }
         }

--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
@@ -64,7 +64,7 @@ object AppRatingInitializer {
             when {
                 ::callback.isInitialized && fragmentManager == null -> callback.showRatingDialog()
                 !::callback.isInitialized && fragmentManager != null -> controller.showDefaultDialog(fragmentManager)
-                else -> throw IllegalArgumentException("Should have one non-nullable callback")
+                else -> throw IllegalArgumentException("Should have one nullable and one non-nullable callback")
             }
         }
     }

--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
@@ -62,7 +62,7 @@ object AppRatingInitializer {
         if (controller.shouldPromptDialog(context)) {
             controller.updateStore(context)
             when {
-                callback != null && fragmentManager == null -> callback.showRatingDialog()
+                callback != null && fragmentManager == null -> callback?.showRatingDialog()
                 callback == null && fragmentManager != null -> controller.showDefaultDialog(fragmentManager)
                 else -> throw IllegalArgumentException("Should have one nullable and one non-nullable callback")
             }

--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/AppRatingInitializer.kt
@@ -19,7 +19,7 @@ object AppRatingInitializer {
         AppRatingController()
     }
 
-    private lateinit var callback: AppRatingDialogCallback
+    private var callback: AppRatingDialogCallback? = null
 
     /**
      * Sets up the conditions to prompt the dialog.
@@ -62,8 +62,8 @@ object AppRatingInitializer {
         if (controller.shouldPromptDialog(context)) {
             controller.updateStore(context)
             when {
-                ::callback.isInitialized && fragmentManager == null -> callback.showRatingDialog()
-                !::callback.isInitialized && fragmentManager != null -> controller.showDefaultDialog(fragmentManager)
+                callback != null && fragmentManager == null -> callback.showRatingDialog()
+                callback == null && fragmentManager != null -> controller.showDefaultDialog(fragmentManager)
                 else -> throw IllegalArgumentException("Should have one nullable and one non-nullable callback")
             }
         }

--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/controller/AppRatingController.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/controller/AppRatingController.kt
@@ -1,7 +1,9 @@
 package com.mindera.skeletoid.apprating.controller
 
 import android.content.Context
+import androidx.fragment.app.FragmentManager
 import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogResponse
+import com.mindera.skeletoid.apprating.dialogs.AppRatingDialog
 import com.mindera.skeletoid.apprating.job.AppRatingJobInitializer
 import com.mindera.skeletoid.apprating.store.AppRatingStore
 import com.mindera.skeletoid.generic.DateUtils
@@ -28,6 +30,8 @@ class AppRatingController {
 
     /**
      * Updates the values in the store.
+     *
+     * @param context Context to access store
      */
     fun updateStore(context: Context) {
         val store = AppRatingStore(context)
@@ -88,6 +92,16 @@ class AppRatingController {
      */
     fun schedulePromptDialogJob() {
         promptTimeInterval?.let { AppRatingJobInitializer.schedule(it) }
+    }
+
+    /**
+     * Shows the default app rating dialog.
+     *
+     * @param fragmentManager Fragment manager used to show dialog
+     */
+    fun showDefaultDialog(fragmentManager: FragmentManager) {
+        AppRatingDialog.newInstance()
+            .show(fragmentManager, AppRatingDialog.TAG)
     }
 
     /**

--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/dialogs/AppRatingDialog.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/dialogs/AppRatingDialog.kt
@@ -1,0 +1,79 @@
+package com.mindera.skeletoid.apprating.dialogs
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.mindera.skeletoid.apprating.R
+import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogResponseCallback
+
+class AppRatingDialog: DialogFragment() {
+
+    companion object {
+        const val TAG = "AppRatingDialog"
+
+        private const val ARGUMENT_TITLE = "ARGUMENT_TITLE"
+        private const val ARGUMENT_MESSAGE = "ARGUMENT_MESSAGE"
+        private const val ARGUMENT_POSITIVE_TEXT = "ARGUMENT_POSITIVE_TEXT"
+        private const val ARGUMENT_NEUTRAL_TEXT = "ARGUMENT_NEUTRAL_TEXT"
+        private const val ARGUMENT_NEGATIVE_TEXT = "ARGUMENT_NEGATIVE_TEXT"
+
+        fun newInstance(
+            title: Int = R.string.dialog_title,
+            message: Int = R.string.dialog_message,
+            positiveButtonText: Int = R.string.dialog_positive_button_text,
+            neutralButtonText: Int = R.string.dialog_neutral_button_text,
+            negativeButtonText: Int = R.string.dialog_negative_button_text
+        ): AppRatingDialog {
+            return AppRatingDialog().apply {
+                arguments = Bundle().apply {
+                    putInt(ARGUMENT_TITLE, title)
+                    putInt(ARGUMENT_MESSAGE, message)
+                    putInt(ARGUMENT_POSITIVE_TEXT, positiveButtonText)
+                    putInt(ARGUMENT_NEUTRAL_TEXT, neutralButtonText)
+                    putInt(ARGUMENT_NEGATIVE_TEXT, negativeButtonText)
+                }
+            }
+        }
+    }
+
+    private var title: Int = 0
+    private var message: Int = 0
+    private var positiveButtonText: Int = 0
+    private var neutralButtonText: Int = 0
+    private var negativeButtonText: Int = 0
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        readArguments()
+
+        return AlertDialog.Builder(activity)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(positiveButtonText) { _, _ ->
+                if (activity is AppRatingDialogResponseCallback) {
+                    (activity as AppRatingDialogResponseCallback).onRateNowClick()
+                }
+            }
+            .setNeutralButton(neutralButtonText) { _, _ ->
+                if (activity is AppRatingDialogResponseCallback) {
+                    (activity as AppRatingDialogResponseCallback).onRateLaterClick()
+                }
+            }
+            .setNegativeButton(negativeButtonText) { _, _ ->
+                if (activity is AppRatingDialogResponseCallback) {
+                    (activity as AppRatingDialogResponseCallback).onNeverRateClick()
+                }
+            }
+            .create()
+    }
+
+    private fun readArguments() {
+        arguments?.let {
+            title = it.getInt(ARGUMENT_TITLE)
+            message = it.getInt(ARGUMENT_MESSAGE)
+            positiveButtonText = it.getInt(ARGUMENT_POSITIVE_TEXT)
+            neutralButtonText = it.getInt(ARGUMENT_NEUTRAL_TEXT)
+            negativeButtonText = it.getInt(ARGUMENT_NEGATIVE_TEXT)
+        }
+    }
+}

--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/dialogs/AppRatingDialog.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/dialogs/AppRatingDialog.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.mindera.skeletoid.apprating.R
 import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogResponseCallback
+import com.mindera.skeletoid.logs.LOG
 
 class AppRatingDialog: DialogFragment() {
 
@@ -52,16 +53,22 @@ class AppRatingDialog: DialogFragment() {
             .setPositiveButton(positiveButtonText) { _, _ ->
                 if (activity is AppRatingDialogResponseCallback) {
                     (activity as AppRatingDialogResponseCallback).onRateNowClick()
+                } else {
+                    LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
                 }
             }
             .setNeutralButton(neutralButtonText) { _, _ ->
                 if (activity is AppRatingDialogResponseCallback) {
                     (activity as AppRatingDialogResponseCallback).onRateLaterClick()
+                } else {
+                    LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
                 }
             }
             .setNegativeButton(negativeButtonText) { _, _ ->
                 if (activity is AppRatingDialogResponseCallback) {
                     (activity as AppRatingDialogResponseCallback).onNeverRateClick()
+                } else {
+                    LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
                 }
             }
             .create()

--- a/apprating/src/main/java/com/mindera/skeletoid/apprating/dialogs/AppRatingDialog.kt
+++ b/apprating/src/main/java/com/mindera/skeletoid/apprating/dialogs/AppRatingDialog.kt
@@ -4,7 +4,9 @@ import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
+import com.mindera.skeletoid.apprating.AppRatingInitializer
 import com.mindera.skeletoid.apprating.R
+import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogResponse
 import com.mindera.skeletoid.apprating.callbacks.AppRatingDialogResponseCallback
 import com.mindera.skeletoid.logs.LOG
 
@@ -51,24 +53,33 @@ class AppRatingDialog: DialogFragment() {
             .setTitle(title)
             .setMessage(message)
             .setPositiveButton(positiveButtonText) { _, _ ->
-                if (activity is AppRatingDialogResponseCallback) {
-                    (activity as AppRatingDialogResponseCallback).onRateNowClick()
-                } else {
-                    LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
+                activity?.let {
+                    if (it is AppRatingDialogResponseCallback) {
+                        (it as AppRatingDialogResponseCallback).onRateNowClick()
+                        AppRatingInitializer.handleDialogResponse(it.applicationContext, AppRatingDialogResponse.RATE_NOW)
+                    } else {
+                        LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
+                    }
                 }
             }
             .setNeutralButton(neutralButtonText) { _, _ ->
-                if (activity is AppRatingDialogResponseCallback) {
-                    (activity as AppRatingDialogResponseCallback).onRateLaterClick()
-                } else {
-                    LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
+                activity?.let {
+                    if (it is AppRatingDialogResponseCallback) {
+                        (it as AppRatingDialogResponseCallback).onRateLaterClick()
+                        AppRatingInitializer.handleDialogResponse(it.applicationContext, AppRatingDialogResponse.RATE_LATER)
+                    } else {
+                        LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
+                    }
                 }
             }
             .setNegativeButton(negativeButtonText) { _, _ ->
-                if (activity is AppRatingDialogResponseCallback) {
-                    (activity as AppRatingDialogResponseCallback).onNeverRateClick()
-                } else {
-                    LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
+                activity?.let {
+                    if (it is AppRatingDialogResponseCallback) {
+                        (it as AppRatingDialogResponseCallback).onNeverRateClick()
+                        AppRatingInitializer.handleDialogResponse(it.applicationContext, AppRatingDialogResponse.NEVER_RATE)
+                    } else {
+                        LOG.e(TAG, "The activity that calls the prompt should implement AppRatingDialogResponseCallback")
+                    }
                 }
             }
             .create()

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
     <string name="email_uri_data">mailto:%1$s?subject=%2$s&amp;body=%3$s</string>
+    <string name="dialog_title">Rate us on Google Play</string>
+    <string name="dialog_message">Your review is important to us.</string>
+    <string name="dialog_positive_button_text">OK, sure</string>
+    <string name="dialog_neutral_button_text">Not now</string>
+    <string name="dialog_negative_button_text">Don\'t ask me again</string>
 </resources>


### PR DESCRIPTION
Implementation of the default rating dialog

HOW TO:

- Call the `init` without passing the callback
- Whenever `promptDialog` is called, a fragment manager should be passed
- The activity of the fragment manager should implement the `AppRatingDialogResponseCallback`