### PR TITLE
ThreadPools: Changed log from Error to Warning

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/threads/threadpools/ScheduledThreadPoolExecutor.java
+++ b/base/src/main/java/com/mindera/skeletoid/threads/threadpools/ScheduledThreadPoolExecutor.java
@@ -30,9 +30,9 @@ public class ScheduledThreadPoolExecutor extends java.util.concurrent.ScheduledT
                 if (future.isDone())
                     future.get();
             } catch (CancellationException ce) {
-                LOG.e(LOG_TAG, "Task was cancelled: " + r.toString());
+                LOG.w(LOG_TAG, "Task was cancelled: " + r.toString());
             } catch (InterruptedException ie) {
-                LOG.e(LOG_TAG, "Task was interrupted: " + r.toString());
+                LOG.w(LOG_TAG, "Task was interrupted: " + r.toString());
                 Thread.currentThread().interrupt(); // ignore/reset
             } catch (Exception e) {
                 t = e.getCause();

--- a/base/src/main/java/com/mindera/skeletoid/threads/threadpools/ThreadPoolExecutor.java
+++ b/base/src/main/java/com/mindera/skeletoid/threads/threadpools/ThreadPoolExecutor.java
@@ -98,9 +98,9 @@ public class ThreadPoolExecutor extends java.util.concurrent.ThreadPoolExecutor 
                 if (future.isDone())
                     future.get();
             } catch (CancellationException ce) {
-                LOG.e(LOG_TAG, "Task was cancelled: " + r.toString());
+                LOG.w(LOG_TAG, "Task was cancelled: " + r.toString());
             } catch (InterruptedException ie) {
-                LOG.e(LOG_TAG, "Task was interrupted: " + r.toString());
+                LOG.w(LOG_TAG, "Task was interrupted: " + r.toString());
                 Thread.currentThread().interrupt(); // ignore/reset
             } catch (Exception e) {
                 t = e.getCause();


### PR DESCRIPTION
To avoid polluting the logs with "false" errors.