### PR TITLE
[fix] WGA-4307 - Fragment triggering DialogFragment while detached fix

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/dialogs/AbstractDialogFragment.kt
+++ b/base/src/main/java/com/mindera/skeletoid/dialogs/AbstractDialogFragment.kt
@@ -105,6 +105,11 @@ abstract class AbstractDialogFragment : DialogFragment() {
             return
         }
 
+        if (targetFragment?.isVisible == false) {
+            LOG.e(LOG_TAG, "Fragment is not visible, ignoring to avoid crash...")
+            return
+        }
+
         val activity = targetFragment?.activity ?: activity
 
         if (isActivityFinishing(activity)) {


### PR DESCRIPTION
Avoid showing a DialogFragment while the original Fragment is not visible
(detached) to avoid crashes