### PR TITLE
Adds a new parameter to differentiate the internal navigation from the external deeplinks

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/routing/OpenUriCommand.kt
+++ b/base/src/main/java/com/mindera/skeletoid/routing/OpenUriCommand.kt
@@ -6,9 +6,14 @@ import android.net.Uri
 
 class OpenUriCommand(private val context: Context, private val deepLink: String) : IRouteCommand {
 
+    companion object {
+        const val IS_INTERNAL_APP_NAVIGATION_EXTRA = "IS_INTERNAL_APP_NAVIGATION_EXTRA"
+    }
+
     override fun navigate() {
         val intent = Intent(Intent.ACTION_VIEW)
         intent.data = Uri.parse(deepLink)
+        intent.putExtra(IS_INTERNAL_APP_NAVIGATION_EXTRA, true)
         context.startActivity(intent)
     }
 }


### PR DESCRIPTION
The new parameter allows us to differentiate the internal app navigation from the external deeplinks.