### PR TITLE
[fix] Allow getCookiesFromUrl to return empty string if no cookies are

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/webview/cookies/CookiesUtils.kt
+++ b/base/src/main/java/com/mindera/skeletoid/webview/cookies/CookiesUtils.kt
@@ -10,7 +10,7 @@ object CookiesUtils {
     fun getCookiesFromUrl(url: String): String {
         val cookieManager = CookieManager.getInstance()
 
-        return cookieManager.getCookie(url)
+        return cookieManager.getCookie(url).orEmpty()
     }
 
     fun getCookiesFromUrlToMap(url: String): HashMap<String, String> {


### PR DESCRIPTION
Allow getCookiesFromUrl to return empty string if no cookies are returned (null value from getCookie(url))