### PR TITLE
Simplified use of create unique concurrent request cache

### DIFF
--- a/rxjava/src/main/kotlin/com/mindera/skeletoid/rxjava/Observable.kt
+++ b/rxjava/src/main/kotlin/com/mindera/skeletoid/rxjava/Observable.kt
@@ -35,6 +35,10 @@ fun <T : Any> Observable<T>.createUniqueConcurrentRequestCache(
     key: String
 ): Observable<T> {
 
+    if (requestMap[key] is Observable) {
+        return requestMap[key] as Observable<T>
+    }
+
     val obs = this.doFinally {
         requestMap.remove(key)
     }


### PR DESCRIPTION
 - Removed the need to check the requestMap for an Observable when
using this extension.