### PR TITLE
[feature] Added WeakRunnable to use to prevent leaks on postDelay

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/threads/utils/WeakRunnable.kt
+++ b/base/src/main/java/com/mindera/skeletoid/threads/utils/WeakRunnable.kt
@@ -1,0 +1,12 @@
+package com.mindera.skeletoid.threads.utils
+
+import java.lang.ref.WeakReference
+
+class WeakRunnable(runnable: Runnable) : Runnable {
+    private val mDelegateRunnable: WeakReference<Runnable> = WeakReference(runnable)
+    override fun run() {
+        val runnable = mDelegateRunnable.get()
+        runnable?.run()
+    }
+
+}

--- a/base/src/main/java/com/mindera/skeletoid/threads/utils/WeakRunnable.kt
+++ b/base/src/main/java/com/mindera/skeletoid/threads/utils/WeakRunnable.kt
@@ -3,9 +3,9 @@ package com.mindera.skeletoid.threads.utils
 import java.lang.ref.WeakReference
 
 class WeakRunnable(runnable: Runnable) : Runnable {
-    private val mDelegateRunnable: WeakReference<Runnable> = WeakReference(runnable)
+    private val delegateRunnable: WeakReference<Runnable> = WeakReference(runnable)
     override fun run() {
-        val runnable = mDelegateRunnable.get()
+        val runnable = delegateRunnable.get()
         runnable?.run()
     }
 


### PR DESCRIPTION
WeakRunnable can be used to use to prevent leaks on postDelay