### PR TITLE
fix/Remove plugins dsl code and use legacy notation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
+apply plugin: "org.sonarqube"
+
 buildscript {
     ext.gradleVersion = '4.0.0'
     ext.kotlinVersion = '1.4.21'
+    ext.sonarqubeVersion = '3.1.1'
 
     repositories {
         google()
@@ -12,12 +15,8 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$gradleVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0"
+        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:$sonarqubeVersion"
     }
-}
-
-plugins {
-    id "org.sonarqube" version "2.8"
 }
 
 allprojects {


### PR DESCRIPTION
Looking at the logs of jitpack we can see that there is a problem with our plugins bock. We are doing as they say but I guess we cab try reverting and using legacy notation.

```
* What went wrong:
Could not compile build file '/home/jitpack/build/build.gradle'.
> startup failed:
  build file '/home/jitpack/build/build.gradle': 107: all buildscript {} blocks must appear before any plugins {} blocks in the script
```