### PR TITLE
[Fix] Update GaAppender to match new specification

### DIFF
--- a/analytics-ga/src/main/java/com/mindera/skeletoid/analytics/appenders/GaAppender.kt
+++ b/analytics-ga/src/main/java/com/mindera/skeletoid/analytics/appenders/GaAppender.kt
@@ -142,7 +142,7 @@ class GaAppender(private val configurationFileId: Int) : IAnalyticsAppender {
 
     override val analyticsId: String = "GoogleAnalytics"
 
-    override fun setUserId(userId: String) {
+    override fun setUserId(userId: String?) {
         tracker?.setClientId(userId)
     }
 


### PR DESCRIPTION
I've updated `IAnalyticsAppender` but forgot to update GaAppender implementation 🤦 