### PR TITLE
Added fix for object hashCode to allow log debug of concurrency issues

### DIFF
--- a/base/src/main/java/com/mindera/skeletoid/logs/LOG.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/LOG.kt
@@ -131,6 +131,11 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
+    fun d(tag: String, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.DEBUG, null, *text)
+    }
+
+    @JvmStatic
     fun d(invokingClass: Any, tag: String, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.DEBUG, null, *text)
     }
@@ -141,6 +146,11 @@ object LOG {
      * @param tag  Tag
      * @param text List of strings
      */
+    @JvmStatic
+    fun e(tag: String, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.ERROR, null, *text)
+    }
+
     @JvmStatic
     fun e(invokingClass: Any, tag: String, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.ERROR, null, *text)
@@ -153,6 +163,11 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
+    fun v(tag: String, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.VERBOSE, null, *text)
+    }
+
+    @JvmStatic
     fun v(invokingClass: Any, tag: String, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.VERBOSE, null, *text)
     }
@@ -163,6 +178,11 @@ object LOG {
      * @param tag  Tag
      * @param text List of strings
      */
+    @JvmStatic
+    fun i(tag: String, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.INFO, null, *text)
+    }
+
     @JvmStatic
     fun i(invokingClass: Any, tag: String, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.INFO, null, *text)
@@ -175,6 +195,11 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
+    fun w(tag: String, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.WARN, null, *text)
+    }
+
+    @JvmStatic
     fun w(invokingClass: Any, tag: String, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.WARN, null, *text)
     }
@@ -185,6 +210,11 @@ object LOG {
      * @param tag  Tag
      * @param text List of strings
      */
+    @JvmStatic
+    fun wtf(tag: String, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.FATAL, null, *text)
+    }
+
     @JvmStatic
     fun wtf(invokingClass: Any, tag: String, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.FATAL, null, *text)
@@ -198,6 +228,11 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
+    fun d(tag: String, t: Throwable, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.DEBUG, t, *text)
+    }
+
+    @JvmStatic
     fun d(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.DEBUG, t, *text)
     }
@@ -209,6 +244,11 @@ object LOG {
      * @param t    Throwable
      * @param text List of strings
      */
+    @JvmStatic
+    fun e(tag: String, t: Throwable, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.ERROR, t, *text)
+    }
+
     @JvmStatic
     fun e(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.ERROR, t, *text)
@@ -222,6 +262,11 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
+    fun v(tag: String, t: Throwable, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.VERBOSE, t, *text)
+    }
+
+    @JvmStatic
     fun v(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.VERBOSE, t, *text)
     }
@@ -233,6 +278,11 @@ object LOG {
      * @param t    Throwable
      * @param text List of strings
      */
+    @JvmStatic
+    fun i(tag: String, t: Throwable, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.INFO, t, *text)
+    }
+
     @JvmStatic
     fun i(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.INFO, t, *text)
@@ -246,6 +296,11 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
+    fun w(tag: String, t: Throwable, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.WARN, t, *text)
+    }
+
+    @JvmStatic
     fun w(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.WARN, t, *text)
     }
@@ -257,6 +312,11 @@ object LOG {
      * @param t    Throwable
      * @param text List of strings
      */
+    @JvmStatic
+    fun wtf(tag: String, t: Throwable, vararg text: String) {
+        instance?.log(null, tag, PRIORITY.FATAL, t, *text)
+    }
+
     @JvmStatic
     fun wtf(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
         instance?.log(invokingClass, tag, PRIORITY.FATAL, t, *text)

--- a/base/src/main/java/com/mindera/skeletoid/logs/LOG.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/LOG.kt
@@ -47,14 +47,13 @@ object LOG {
     @JvmStatic
     @Synchronized
     fun init(
-        invokingClass: Any,
         context: Context,
         packageName: String? = null,
         logAppenders: List<ILogAppender> = emptyList()
     ): Set<String> {
         val logger = getInstance(context, packageName)
         logger.removeAllAppenders()
-        return logger.addAppenders(invokingClass, context, logAppenders)
+        return logger.addAppenders(context, logAppenders)
     }
 
     /**
@@ -76,11 +75,10 @@ object LOG {
      */
     @JvmStatic
     fun addAppenders(
-        invokingClass: Any,
         context: Context,
         logAppenders: List<ILogAppender>
     ): Set<String> {
-        return instance?.addAppenders(invokingClass, context, logAppenders)
+        return instance?.addAppenders(context, logAppenders)
             ?: throw UninitializedPropertyAccessException("Please call init() before using")
     }
 

--- a/base/src/main/java/com/mindera/skeletoid/logs/LOG.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/LOG.kt
@@ -47,13 +47,14 @@ object LOG {
     @JvmStatic
     @Synchronized
     fun init(
+        invokingClass: Any,
         context: Context,
         packageName: String? = null,
         logAppenders: List<ILogAppender> = emptyList()
     ): Set<String> {
         val logger = getInstance(context, packageName)
         logger.removeAllAppenders()
-        return logger.addAppenders(context, logAppenders)
+        return logger.addAppenders(invokingClass, context, logAppenders)
     }
 
     /**
@@ -75,10 +76,11 @@ object LOG {
      */
     @JvmStatic
     fun addAppenders(
+        invokingClass: Any,
         context: Context,
         logAppenders: List<ILogAppender>
     ): Set<String> {
-        return instance?.addAppenders(context, logAppenders)
+        return instance?.addAppenders(invokingClass, context, logAppenders)
             ?: throw UninitializedPropertyAccessException("Please call init() before using")
     }
 
@@ -129,8 +131,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun d(tag: String, vararg text: String) {
-        instance?.log(tag, PRIORITY.DEBUG, null, *text)
+    fun d(invokingClass: Any, tag: String, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.DEBUG, null, *text)
     }
 
     /**
@@ -140,8 +142,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun e(tag: String, vararg text: String) {
-        instance?.log(tag, PRIORITY.ERROR, null, *text)
+    fun e(invokingClass: Any, tag: String, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.ERROR, null, *text)
     }
 
     /**
@@ -151,8 +153,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun v(tag: String, vararg text: String) {
-        instance?.log(tag, PRIORITY.VERBOSE, null, *text)
+    fun v(invokingClass: Any, tag: String, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.VERBOSE, null, *text)
     }
 
     /**
@@ -162,8 +164,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun i(tag: String, vararg text: String) {
-        instance?.log(tag, PRIORITY.INFO, null, *text)
+    fun i(invokingClass: Any, tag: String, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.INFO, null, *text)
     }
 
     /**
@@ -173,8 +175,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun w(tag: String, vararg text: String) {
-        instance?.log(tag, PRIORITY.WARN, null, *text)
+    fun w(invokingClass: Any, tag: String, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.WARN, null, *text)
     }
 
     /**
@@ -184,8 +186,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun wtf(tag: String, vararg text: String) {
-        instance?.log(tag, PRIORITY.FATAL, null, *text)
+    fun wtf(invokingClass: Any, tag: String, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.FATAL, null, *text)
     }
 
     /**
@@ -196,8 +198,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun d(tag: String, t: Throwable, vararg text: String) {
-        instance?.log(tag, PRIORITY.DEBUG, t, *text)
+    fun d(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.DEBUG, t, *text)
     }
 
     /**
@@ -208,8 +210,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun e(tag: String, t: Throwable, vararg text: String) {
-        instance?.log(tag, PRIORITY.ERROR, t, *text)
+    fun e(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.ERROR, t, *text)
     }
 
     /**
@@ -220,8 +222,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun v(tag: String, t: Throwable, vararg text: String) {
-        instance?.log(tag, PRIORITY.VERBOSE, t, *text)
+    fun v(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.VERBOSE, t, *text)
     }
 
     /**
@@ -232,8 +234,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun i(tag: String, t: Throwable, vararg text: String) {
-        instance?.log(tag, PRIORITY.INFO, t, *text)
+    fun i(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.INFO, t, *text)
     }
 
     /**
@@ -244,8 +246,8 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun w(tag: String, t: Throwable, vararg text: String) {
-        instance?.log(tag, PRIORITY.WARN, t, *text)
+    fun w(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.WARN, t, *text)
     }
 
     /**
@@ -256,7 +258,7 @@ object LOG {
      * @param text List of strings
      */
     @JvmStatic
-    fun wtf(tag: String, t: Throwable, vararg text: String) {
-        instance?.log(tag, PRIORITY.FATAL, t, *text)
+    fun wtf(invokingClass: Any, tag: String, t: Throwable, vararg text: String) {
+        instance?.log(invokingClass, tag, PRIORITY.FATAL, t, *text)
     }
 }

--- a/base/src/main/java/com/mindera/skeletoid/logs/LoggerManager.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/LoggerManager.kt
@@ -55,7 +55,7 @@ internal class LoggerManager : ILoggerManager {
      * Enables or disables logging to console/logcat.
      */
     override fun addAppenders(
-        invokingClass: Any,
+        invokingClass: Any?,
         context: Context,
         logAppenders: List<ILogAppender>
     ): Set<String> {
@@ -121,7 +121,7 @@ internal class LoggerManager : ILoggerManager {
     }
 
     override fun log(
-        invokingClass: Any,
+        invokingClass: Any?,
         tag: String,
         priority: PRIORITY,
         t: Throwable?,

--- a/base/src/main/java/com/mindera/skeletoid/logs/LoggerManager.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/LoggerManager.kt
@@ -55,6 +55,7 @@ internal class LoggerManager : ILoggerManager {
      * Enables or disables logging to console/logcat.
      */
     override fun addAppenders(
+        invokingClass: Any,
         context: Context,
         logAppenders: List<ILogAppender>
     ): Set<String> {
@@ -62,7 +63,8 @@ internal class LoggerManager : ILoggerManager {
         for (logAppender in logAppenders) {
             val loggerId = logAppender.loggerId
             if (this.logAppenders.containsKey(loggerId)) {
-                log(LOG_TAG, PRIORITY.ERROR, null, "Replacing Log Appender with ID: $loggerId")
+                log(invokingClass,
+                    LOG_TAG, PRIORITY.ERROR, null, "Replacing Log Appender with ID: $loggerId")
                 val oldLogAppender = this.logAppenders.remove(loggerId)
                 oldLogAppender!!.disableAppender()
             }
@@ -119,6 +121,7 @@ internal class LoggerManager : ILoggerManager {
     }
 
     override fun log(
+        invokingClass: Any,
         tag: String,
         priority: PRIORITY,
         t: Throwable?,
@@ -128,7 +131,7 @@ internal class LoggerManager : ILoggerManager {
             val log = String.format(
                 LOG_FORMAT_4ARGS,
                 tag,
-                LogAppenderUtils.getObjectHash(tag),
+                LogAppenderUtils.getObjectHash(invokingClass),
                 ThreadUtils.currentThreadName,
                 LogAppenderUtils.getLogString(*text)
             )

--- a/base/src/main/java/com/mindera/skeletoid/logs/interfaces/ILoggerManager.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/interfaces/ILoggerManager.kt
@@ -40,7 +40,6 @@ interface ILoggerManager {
      * @return Ids of the logs enabled by their order
      */
     fun addAppenders(
-        invokingClass: Any? = null,
         context: Context,
         logAppenders: List<ILogAppender>
     ): Set<String>

--- a/base/src/main/java/com/mindera/skeletoid/logs/interfaces/ILoggerManager.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/interfaces/ILoggerManager.kt
@@ -18,6 +18,7 @@ interface ILoggerManager {
      * @param text     Log text
      */
     fun log(
+        invokingClass: Any,
         tag: String,
         priority: PRIORITY,
         t: Throwable? = null,
@@ -39,6 +40,7 @@ interface ILoggerManager {
      * @return Ids of the logs enabled by their order
      */
     fun addAppenders(
+        invokingClass: Any,
         context: Context,
         logAppenders: List<ILogAppender>
     ): Set<String>

--- a/base/src/main/java/com/mindera/skeletoid/logs/interfaces/ILoggerManager.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/interfaces/ILoggerManager.kt
@@ -18,7 +18,7 @@ interface ILoggerManager {
      * @param text     Log text
      */
     fun log(
-        invokingClass: Any,
+        invokingClass: Any? = null,
         tag: String,
         priority: PRIORITY,
         t: Throwable? = null,
@@ -40,7 +40,7 @@ interface ILoggerManager {
      * @return Ids of the logs enabled by their order
      */
     fun addAppenders(
-        invokingClass: Any,
+        invokingClass: Any? = null,
         context: Context,
         logAppenders: List<ILogAppender>
     ): Set<String>

--- a/base/src/main/java/com/mindera/skeletoid/logs/utils/LogAppenderUtils.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/utils/LogAppenderUtils.kt
@@ -70,15 +70,15 @@ object LogAppenderUtils {
      * @return The hashcode of the object in a printable string
      */
     @JvmStatic
-    fun getObjectHash(any: Any): String {
-        return run {
+    fun getObjectHash(obj: Any?): String {
+        return obj?.let {
             val stringBuilder = StringBuilder()
             stringBuilder.append("[")
-            stringBuilder.append(any.javaClass.simpleName)
+            stringBuilder.append(obj.javaClass.simpleName)
             stringBuilder.append("#")
-            stringBuilder.append(any.hashCode())
+            stringBuilder.append(obj.hashCode())
             stringBuilder.append("] ")
             stringBuilder.toString()
-        }
+        } ?: ""
     }
 }

--- a/base/src/main/java/com/mindera/skeletoid/logs/utils/LogAppenderUtils.kt
+++ b/base/src/main/java/com/mindera/skeletoid/logs/utils/LogAppenderUtils.kt
@@ -70,8 +70,8 @@ object LogAppenderUtils {
      * @return The hashcode of the object in a printable string
      */
     @JvmStatic
-    fun getObjectHash(obj: Any?): String {
-        return obj?.let {
+    fun getObjectHash(obj: Any?): String? =
+        obj?.let {
             val stringBuilder = StringBuilder()
             stringBuilder.append("[")
             stringBuilder.append(obj.javaClass.simpleName)
@@ -79,6 +79,5 @@ object LogAppenderUtils {
             stringBuilder.append(obj.hashCode())
             stringBuilder.append("] ")
             stringBuilder.toString()
-        } ?: ""
-    }
+        }
 }

--- a/base/src/test/java/com/mindera/skeletoid/logs/LOGUnitTest.kt
+++ b/base/src/test/java/com/mindera/skeletoid/logs/LOGUnitTest.kt
@@ -75,8 +75,8 @@ class LOGUnitTest {
         PowerMockito.mockStatic(AndroidUtils::class.java)
         Mockito.`when`(getApplicationPackage(context))
             .thenReturn("package")
-        init(context)
-        addAppenders(context, appenders)
+        init(this, context)
+        addAppenders(this, context, appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -85,7 +85,7 @@ class LOGUnitTest {
 
     @Test
     fun testInitWithContextAndPackageName() {
-        init(context, packageName)
+        init(this, context, packageName)
         Assert.assertTrue(isInitialized)
     }
 
@@ -101,7 +101,7 @@ class LOGUnitTest {
         PowerMockito.mockStatic(AndroidUtils::class.java)
         Mockito.`when`(getApplicationPackage(context))
             .thenReturn("package")
-        init(context, logAppenders = appenders)
+        init(this, context, logAppenders = appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -117,7 +117,7 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -133,8 +133,8 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
-        d(TAG, TEXT)
+        init(this, context, packageName, appenders)
+        d(this, TAG, TEXT)
 
         //This is ugly.. but I don't see another way.
         val log = String.format(
@@ -158,8 +158,8 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
-        e(TAG, TEXT)
+        init(this, context, packageName, appenders)
+        e(this, TAG, TEXT)
 
         //This is ugly.. but I don't see another way.
         val log = String.format(
@@ -183,8 +183,8 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
-        w(TAG, TEXT)
+        init(this, context, packageName, appenders)
+        w(this, TAG, TEXT)
 
         //This is ugly.. but I don't see another way.
         val log = String.format(
@@ -212,12 +212,12 @@ class LOGUnitTest {
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
-        init(context, packageName, appenders)
-        wtf(TAG, TEXT)
+        init(this, context, packageName, appenders)
+        wtf(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.FATAL, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.FATAL, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.FATAL, null, log)
@@ -236,12 +236,12 @@ class LOGUnitTest {
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
-        init(context, packageName, appenders)
-        i(TAG, TEXT)
+        init(this, context, packageName, appenders)
+        i(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.INFO, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.INFO, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.INFO, null, log)
@@ -256,13 +256,13 @@ class LOGUnitTest {
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         deinit()
-        d(TAG, TEXT)
+        d(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.DEBUG, null, log)
     }
 
@@ -275,13 +275,13 @@ class LOGUnitTest {
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         deinit()
-        e(TAG, TEXT)
+        e(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.ERROR, null, log)
     }
 
@@ -294,13 +294,13 @@ class LOGUnitTest {
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         deinit()
-        w(TAG, TEXT)
+        w(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.WARN, null, log)
     }
 
@@ -313,13 +313,13 @@ class LOGUnitTest {
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         deinit()
-        wtf(TAG, TEXT)
+        wtf(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.FATAL, null, log)
     }
 
@@ -332,13 +332,13 @@ class LOGUnitTest {
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         deinit()
-        i(TAG, TEXT)
+        i(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.INFO, null, log)
     }
 
@@ -351,14 +351,14 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         val e = Exception()
-        d(TAG, e, TEXT)
+        d(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -376,14 +376,14 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         val e = Exception()
-        e(TAG, e, TEXT)
+        e(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -401,14 +401,14 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         val e = Exception()
-        w(TAG, e, TEXT)
+        w(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -426,14 +426,14 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         val e = Exception()
-        wtf(TAG, e, TEXT)
+        wtf(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -451,9 +451,9 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         val e = Exception()
-        i(TAG, e, TEXT)
+        i(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
         val log = String.format(
             LOG_FORMAT_4ARGS,
@@ -476,14 +476,14 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
+        init(this, context, packageName, appenders)
         val e = Exception()
-        v(TAG, e, TEXT)
+        v(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -501,13 +501,13 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName, appenders)
-        v(TAG, TEXT)
+        init(this, context, packageName, appenders)
+        v(this, TAG, TEXT)
         //This is ugly.. but I don't see another way.
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -528,8 +528,8 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName)
-        val ids = addAppenders(context, appenders)
+        init(this, context, packageName)
+        val ids = addAppenders(this, context, appenders)
         removeAppenders(context, ids)
         Mockito.verify(appenderA).disableAppender()
         Mockito.verify(appenderB).disableAppender()
@@ -545,8 +545,8 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(context, packageName)
-        val ids = addAppenders(context, appenders)
+        init(this, context, packageName)
+        val ids = addAppenders(this, context, appenders)
         val idsList: MutableList<String> =
             ArrayList(ids)
         for (id in ids) {

--- a/base/src/test/java/com/mindera/skeletoid/logs/LOGUnitTest.kt
+++ b/base/src/test/java/com/mindera/skeletoid/logs/LOGUnitTest.kt
@@ -38,7 +38,7 @@ import java.util.HashSet
 class LOGUnitTest {
 
     companion object {
-        private const val LOG_FORMAT_4ARGS = LoggerManager.LOG_FORMAT_4ARGS
+        private const val LOG_FORMAT = LoggerManager.LOG_FORMAT
         private const val TAG = "TAG"
         private const val TEXT = "Text"
         private const val packageName = "my.package.name"
@@ -75,8 +75,8 @@ class LOGUnitTest {
         PowerMockito.mockStatic(AndroidUtils::class.java)
         Mockito.`when`(getApplicationPackage(context))
             .thenReturn("package")
-        init(this, context)
-        addAppenders(this, context, appenders)
+        init(context)
+        addAppenders(context, appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -85,7 +85,7 @@ class LOGUnitTest {
 
     @Test
     fun testInitWithContextAndPackageName() {
-        init(this, context, packageName)
+        init( context, packageName)
         Assert.assertTrue(isInitialized)
     }
 
@@ -101,7 +101,7 @@ class LOGUnitTest {
         PowerMockito.mockStatic(AndroidUtils::class.java)
         Mockito.`when`(getApplicationPackage(context))
             .thenReturn("package")
-        init(this, context, logAppenders = appenders)
+        init(context, logAppenders = appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -117,7 +117,7 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -133,17 +133,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         d(this, TAG, TEXT)
 
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.DEBUG, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.DEBUG, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.DEBUG, null, log)
@@ -158,17 +160,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         e(this, TAG, TEXT)
 
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.ERROR, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.ERROR, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.ERROR, null, log)
@@ -183,17 +187,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         w(this, TAG, TEXT)
 
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.WARN, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.WARN, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.WARN, null, log)
@@ -209,14 +215,16 @@ class LOGUnitTest {
         appenders.add(appenderB)
         appenders.add(appenderC)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
-        init(this, context, packageName, appenders)
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
+        init(context, packageName, appenders)
         wtf(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.FATAL, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.FATAL, null, log)
@@ -233,14 +241,16 @@ class LOGUnitTest {
         appenders.add(appenderB)
         appenders.add(appenderC)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
-        init(this, context, packageName, appenders)
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
+        init(context, packageName, appenders)
         i(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.INFO, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.INFO, null, log)
@@ -253,14 +263,16 @@ class LOGUnitTest {
         val appenderA = mockAppender("A")
         appenders.add(appenderA)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
-        init(this, context, packageName, appenders)
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
+        init(context, packageName, appenders)
         deinit()
         d(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.DEBUG, null, log)
@@ -272,14 +284,16 @@ class LOGUnitTest {
         val appenderA = mockAppender("A")
         appenders.add(appenderA)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
-        init(this, context, packageName, appenders)
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
+        init(context, packageName, appenders)
         deinit()
         e(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.ERROR, null, log)
@@ -291,14 +305,16 @@ class LOGUnitTest {
         val appenderA = mockAppender("A")
         appenders.add(appenderA)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
-        init(this, context, packageName, appenders)
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
+        init(context, packageName, appenders)
         deinit()
         w(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.WARN, null, log)
@@ -310,14 +326,16 @@ class LOGUnitTest {
         val appenderA = mockAppender("A")
         appenders.add(appenderA)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
-        init(this, context, packageName, appenders)
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
+        init(context, packageName, appenders)
         deinit()
         wtf(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.FATAL, null, log)
@@ -329,14 +347,16 @@ class LOGUnitTest {
         val appenderA = mockAppender("A")
         appenders.add(appenderA)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
-        init(this, context, packageName, appenders)
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
+        init(context, packageName, appenders)
         deinit()
         i(this, TAG, TEXT)
         Mockito.verify(appenderA, Mockito.times(0)).log(LOG.PRIORITY.INFO, null, log)
@@ -351,17 +371,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         val e = Exception()
         d(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.DEBUG, e, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.DEBUG, e, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.DEBUG, e, log)
@@ -376,17 +398,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         val e = Exception()
         e(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.ERROR, e, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.ERROR, e, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.ERROR, e, log)
@@ -401,17 +425,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         val e = Exception()
         w(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.WARN, e, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.WARN, e, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.WARN, e, log)
@@ -426,17 +452,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         val e = Exception()
         wtf(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.FATAL, e, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.FATAL, e, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.FATAL, e, log)
@@ -451,17 +479,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         val e = Exception()
         i(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.INFO, e, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.INFO, e, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.INFO, e, log)
@@ -476,17 +506,19 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         val e = Exception()
         v(this, TAG, e, TEXT)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1)).log(LOG.PRIORITY.VERBOSE, e, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(LOG.PRIORITY.VERBOSE, e, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(LOG.PRIORITY.VERBOSE, e, log)
@@ -501,16 +533,18 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName, appenders)
+        init(context, packageName, appenders)
         v(this, TAG, TEXT)
         //This is ugly.. but I don't see another way.
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(
+            TEXT
+        ))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(LOG.PRIORITY.VERBOSE, null, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -528,8 +562,8 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName)
-        val ids = addAppenders(this, context, appenders)
+        init(context, packageName)
+        val ids = addAppenders(context, appenders)
         removeAppenders(context, ids)
         Mockito.verify(appenderA).disableAppender()
         Mockito.verify(appenderB).disableAppender()
@@ -545,8 +579,8 @@ class LOGUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        init(this, context, packageName)
-        val ids = addAppenders(this, context, appenders)
+        init(context, packageName)
+        val ids = addAppenders(context, appenders)
         val idsList: MutableList<String> =
             ArrayList(ids)
         for (id in ids) {

--- a/base/src/test/java/com/mindera/skeletoid/logs/LoggerManagerUnitTest.kt
+++ b/base/src/test/java/com/mindera/skeletoid/logs/LoggerManagerUnitTest.kt
@@ -5,6 +5,7 @@ import com.mindera.skeletoid.generic.AndroidUtils
 import com.mindera.skeletoid.generic.AndroidUtils.getApplicationPackage
 import com.mindera.skeletoid.logs.LOG.PRIORITY
 import com.mindera.skeletoid.logs.appenders.interfaces.ILogAppender
+import com.mindera.skeletoid.logs.utils.LogAppenderUtils
 import com.mindera.skeletoid.logs.utils.LogAppenderUtils.getLogString
 import com.mindera.skeletoid.logs.utils.LogAppenderUtils.getObjectHash
 import com.mindera.skeletoid.threads.utils.ThreadUtils
@@ -26,7 +27,7 @@ import java.util.HashSet
 @PrepareForTest(AndroidUtils::class)
 class LoggerManagerUnitTest {
     companion object {
-        private const val LOG_FORMAT_4ARGS = LoggerManager.LOG_FORMAT_4ARGS
+        private const val LOG_FORMAT = LoggerManager.LOG_FORMAT
 
         private const val TAG = "TAG"
         private const val TEXT = "Text"
@@ -58,7 +59,7 @@ class LoggerManagerUnitTest {
     @Test
     fun testAddAppendersEmpty() {
         val loggerManager = LoggerManager(packageName)
-        val appendersIds = loggerManager.addAppenders(this, context, ArrayList())
+        val appendersIds = loggerManager.addAppenders(context, ArrayList())
         Assert.assertNotNull(appendersIds)
         Assert.assertEquals(0, appendersIds.size)
     }
@@ -73,7 +74,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        val appendersIds = loggerManager.addAppenders(this, context, appenders)
+        val appendersIds = loggerManager.addAppenders(context, appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -94,7 +95,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB1)
         appenders.add(appenderB2)
-        val appendersIds = loggerManager.addAppenders(this, context, appenders)
+        val appendersIds = loggerManager.addAppenders(context, appenders)
         Assert.assertNotNull(appendersIds)
         Assert.assertEquals(2, appendersIds.size)
         Assert.assertTrue(appendersIds.contains("A"))
@@ -118,7 +119,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        val appendersIds = loggerManager.addAppenders(this, context, appenders)
+        val appendersIds = loggerManager.addAppenders(context, appenders)
         loggerManager.removeAppenders(context, appendersIds)
         Mockito.verify(appenderA, Mockito.times(1)).disableAppender()
         Mockito.verify(appenderB, Mockito.times(1)).disableAppender()
@@ -137,7 +138,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderB)
         appenders.add(appenderC)
         appendersId.add("A")
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.removeAppenders(context, HashSet(appendersId))
         Mockito.verify(appenderA, Mockito.times(1)).disableAppender()
     }
@@ -152,7 +153,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.removeAllAppenders()
         Mockito.verify(appenderA, Mockito.times(1)).disableAppender()
         Mockito.verify(appenderB, Mockito.times(1)).disableAppender()
@@ -169,15 +170,17 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.DEBUG, null, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
+
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.DEBUG, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.DEBUG, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.DEBUG, null, log)
@@ -193,15 +196,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.ERROR, null, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.ERROR, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.ERROR, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.ERROR, null, log)
@@ -217,15 +220,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.WARN, null, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.WARN, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.WARN, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.WARN, null, log)
@@ -241,15 +244,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.FATAL, null, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.FATAL, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.FATAL, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.FATAL, null, log)
@@ -265,15 +268,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.INFO, null, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.INFO, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.INFO, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.INFO, null, log)
@@ -289,15 +292,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.VERBOSE, null, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(PRIORITY.VERBOSE, null, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -317,15 +320,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.DEBUG, throwable, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(PRIORITY.DEBUG, throwable, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -345,15 +348,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.ERROR, throwable, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(PRIORITY.ERROR, throwable, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -373,15 +376,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.WARN, throwable, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(PRIORITY.WARN, throwable, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -401,15 +404,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.FATAL, throwable, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(PRIORITY.FATAL, throwable, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -429,15 +432,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.INFO, throwable, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(PRIORITY.INFO, throwable, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -457,15 +460,15 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.VERBOSE, throwable, TEXT)
-        val log = String.format(
-            LOG_FORMAT_4ARGS,
+        val headers = listOfNotNull(
             TAG,
             getObjectHash(this),
             ThreadUtils.currentThreadName,
-            getLogString(TEXT)
-        )
+        ).joinToString(separator = " ")
+
+        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1))
             .log(PRIORITY.VERBOSE, throwable, log)
         Mockito.verify(appenderB, Mockito.times(1))
@@ -479,7 +482,7 @@ class LoggerManagerUnitTest {
         val appenders: List<ILogAppender> = ArrayList()
         val spyAppenders = Mockito.spy(appenders)
         val loggerManager = LoggerManager(packageName)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.VERBOSE, null, TEXT)
         Mockito.verify(spyAppenders, Mockito.times(0)).listIterator()
     }
@@ -489,7 +492,7 @@ class LoggerManagerUnitTest {
         val appenders: List<ILogAppender> = ArrayList()
         val spyAppenders = Mockito.spy(appenders)
         val loggerManager = LoggerManager(packageName)
-        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.addAppenders(context, appenders)
         loggerManager.log(this, TAG, PRIORITY.VERBOSE, Throwable(), TEXT)
         Mockito.verify(spyAppenders, Mockito.times(0)).listIterator()
     }

--- a/base/src/test/java/com/mindera/skeletoid/logs/LoggerManagerUnitTest.kt
+++ b/base/src/test/java/com/mindera/skeletoid/logs/LoggerManagerUnitTest.kt
@@ -58,7 +58,7 @@ class LoggerManagerUnitTest {
     @Test
     fun testAddAppendersEmpty() {
         val loggerManager = LoggerManager(packageName)
-        val appendersIds = loggerManager.addAppenders(context, ArrayList())
+        val appendersIds = loggerManager.addAppenders(this, context, ArrayList())
         Assert.assertNotNull(appendersIds)
         Assert.assertEquals(0, appendersIds.size)
     }
@@ -73,7 +73,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        val appendersIds = loggerManager.addAppenders(context, appenders)
+        val appendersIds = loggerManager.addAppenders(this, context, appenders)
         Mockito.verify(appenderA, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderB, Mockito.times(1)).enableAppender(context)
         Mockito.verify(appenderC, Mockito.times(1)).enableAppender(context)
@@ -94,7 +94,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB1)
         appenders.add(appenderB2)
-        val appendersIds = loggerManager.addAppenders(context, appenders)
+        val appendersIds = loggerManager.addAppenders(this, context, appenders)
         Assert.assertNotNull(appendersIds)
         Assert.assertEquals(2, appendersIds.size)
         Assert.assertTrue(appendersIds.contains("A"))
@@ -118,7 +118,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        val appendersIds = loggerManager.addAppenders(context, appenders)
+        val appendersIds = loggerManager.addAppenders(this, context, appenders)
         loggerManager.removeAppenders(context, appendersIds)
         Mockito.verify(appenderA, Mockito.times(1)).disableAppender()
         Mockito.verify(appenderB, Mockito.times(1)).disableAppender()
@@ -137,7 +137,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderB)
         appenders.add(appenderC)
         appendersId.add("A")
-        loggerManager.addAppenders(context, appenders)
+        loggerManager.addAppenders(this, context, appenders)
         loggerManager.removeAppenders(context, HashSet(appendersId))
         Mockito.verify(appenderA, Mockito.times(1)).disableAppender()
     }
@@ -152,7 +152,7 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
+        loggerManager.addAppenders(this, context, appenders)
         loggerManager.removeAllAppenders()
         Mockito.verify(appenderA, Mockito.times(1)).disableAppender()
         Mockito.verify(appenderB, Mockito.times(1)).disableAppender()
@@ -169,12 +169,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.DEBUG, null, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.DEBUG, null, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -193,12 +193,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.ERROR, null, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.ERROR, null, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -217,12 +217,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.WARN, null, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.WARN, null, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -241,12 +241,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.FATAL, null, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.FATAL, null, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -265,12 +265,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.INFO, null, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.INFO, null, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -289,12 +289,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.VERBOSE, null, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.VERBOSE, null, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -317,12 +317,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.DEBUG, throwable, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.DEBUG, throwable, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -345,12 +345,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.ERROR, throwable, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.ERROR, throwable, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -373,12 +373,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.WARN, throwable, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.WARN, throwable, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -401,12 +401,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.FATAL, throwable, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.FATAL, throwable, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -429,12 +429,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.INFO, throwable, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.INFO, throwable, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -457,12 +457,12 @@ class LoggerManagerUnitTest {
         appenders.add(appenderA)
         appenders.add(appenderB)
         appenders.add(appenderC)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.VERBOSE, throwable, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.VERBOSE, throwable, TEXT)
         val log = String.format(
             LOG_FORMAT_4ARGS,
             TAG,
-            getObjectHash(TAG),
+            getObjectHash(this),
             ThreadUtils.currentThreadName,
             getLogString(TEXT)
         )
@@ -479,8 +479,8 @@ class LoggerManagerUnitTest {
         val appenders: List<ILogAppender> = ArrayList()
         val spyAppenders = Mockito.spy(appenders)
         val loggerManager = LoggerManager(packageName)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.VERBOSE, null, TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.VERBOSE, null, TEXT)
         Mockito.verify(spyAppenders, Mockito.times(0)).listIterator()
     }
 
@@ -489,8 +489,8 @@ class LoggerManagerUnitTest {
         val appenders: List<ILogAppender> = ArrayList()
         val spyAppenders = Mockito.spy(appenders)
         val loggerManager = LoggerManager(packageName)
-        loggerManager.addAppenders(context, appenders)
-        loggerManager.log(TAG, PRIORITY.VERBOSE, Throwable(), TEXT)
+        loggerManager.addAppenders(this, context, appenders)
+        loggerManager.log(this, TAG, PRIORITY.VERBOSE, Throwable(), TEXT)
         Mockito.verify(spyAppenders, Mockito.times(0)).listIterator()
     }
 

--- a/base/src/test/java/com/mindera/skeletoid/logs/LoggerManagerUnitTest.kt
+++ b/base/src/test/java/com/mindera/skeletoid/logs/LoggerManagerUnitTest.kt
@@ -179,7 +179,7 @@ class LoggerManagerUnitTest {
             ThreadUtils.currentThreadName,
         ).joinToString(separator = " ")
 
-        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
+        val log = String.format(LOG_FORMAT, headers, getLogString(TEXT))
 
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.DEBUG, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.DEBUG, null, log)
@@ -204,7 +204,7 @@ class LoggerManagerUnitTest {
             ThreadUtils.currentThreadName,
         ).joinToString(separator = " ")
 
-        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
+        val log = String.format(LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.ERROR, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.ERROR, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.ERROR, null, log)
@@ -228,7 +228,7 @@ class LoggerManagerUnitTest {
             ThreadUtils.currentThreadName,
         ).joinToString(separator = " ")
 
-        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
+        val log = String.format(LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.WARN, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.WARN, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.WARN, null, log)
@@ -252,7 +252,7 @@ class LoggerManagerUnitTest {
             ThreadUtils.currentThreadName,
         ).joinToString(separator = " ")
 
-        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
+        val log = String.format(LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.FATAL, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.FATAL, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.FATAL, null, log)
@@ -276,7 +276,7 @@ class LoggerManagerUnitTest {
             ThreadUtils.currentThreadName,
         ).joinToString(separator = " ")
 
-        val log = String.format(LoggerManager.LOG_FORMAT, headers, getLogString(TEXT))
+        val log = String.format(LOG_FORMAT, headers, getLogString(TEXT))
         Mockito.verify(appenderA, Mockito.times(1)).log(PRIORITY.INFO, null, log)
         Mockito.verify(appenderB, Mockito.times(1)).log(PRIORITY.INFO, null, log)
         Mockito.verify(appenderC, Mockito.times(1)).log(PRIORITY.INFO, null, log)

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,11 @@ apply plugin: "org.sonarqube"
 
 buildscript {
     ext.gradleVersion = '4.0.0'
-    ext.kotlinVersion = '1.4.21'
+    ext.kotlinVersion = '1.5.31'
     ext.sonarqubeVersion = '3.1.1'
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://jitpack.io" }
@@ -22,7 +21,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url "http://dl.bintray.com/typesafe/maven-releases" }
         maven { url "https://maven.google.com" }
@@ -48,7 +46,7 @@ ext {
     annotationVersion = '1.1.0'
 
     //Firebase
-    firebaseAnalyticsVersion = '19.0.0'
+    firebaseAnalyticsVersion = '19.0.1'
     firebasePerfVersion = '19.0.8'
 
     //Play Services


### PR DESCRIPTION
Currently the LOG was always using TAG String as the source of the hashCode of the object. That is not valid, and defects the initial purpose which was broken when we migrated this from Java to Kotlin.